### PR TITLE
[TECH-100] feat: Support passing request metadata when uploading files

### DIFF
--- a/Source/RuntimeFilesDownloader/Private/FileFromStorageUploader.cpp
+++ b/Source/RuntimeFilesDownloader/Private/FileFromStorageUploader.cpp
@@ -9,7 +9,7 @@
 #include "GenericPlatform/GenericPlatformFile.h"
 
 UFileFromStorageUploader* UFileFromStorageUploader::UploadFileFromStorage(
-	const FString&                          URL, const FString& FilePath, float Timeout, const FOnDownloadProgress& OnProgress,
+	const FString& URL, const FString& FilePath, float Timeout, const FOnDownloadProgress& OnProgress,
 	const FOnFileFromStorageUploadComplete& OnComplete)
 {
 	return UploadFileFromStorage(URL, FilePath, Timeout, FOnDownloadProgressNative::CreateLambda(
@@ -22,14 +22,14 @@ UFileFromStorageUploader* UFileFromStorageUploader::UploadFileFromStorage(
 }
 
 UFileFromStorageUploader* UFileFromStorageUploader::UploadFileFromStorage(
-	const FString&                          URL, const FString& SavePath, float Timeout, const FOnDownloadProgressNative& OnProgress, const
-	FOnFileFromStorageUploadCompleteNative& OnComplete)
+	const FString& URL, const FString& SavePath, float Timeout, const FOnDownloadProgressNative& OnProgress, const
+	FOnFileFromStorageUploadCompleteNative& OnComplete, const TMap<FString, FString>& Headers)
 {
 	UFileFromStorageUploader* Uploader = NewObject<UFileFromStorageUploader>(StaticClass());
 	Uploader->AddToRoot();
 	Uploader->OnDownloadProgress = OnProgress;
 	Uploader->OnUploadComplete = OnComplete;
-	Uploader->UploadFileFromStorage(URL, SavePath, Timeout);
+	Uploader->UploadFileFromStorage(URL, SavePath, Timeout, Headers);
 	return Uploader;
 }
 
@@ -43,7 +43,7 @@ bool UFileFromStorageUploader::CancelDownload()
 	return false;
 }
 
-void UFileFromStorageUploader::UploadFileFromStorage(const FString& URL, const FString& SourceFile, float Timeout)
+void UFileFromStorageUploader::UploadFileFromStorage(const FString& URL, const FString& SourceFile, float Timeout, const TMap<FString, FString>& Headers)
 {
 	if (URL.IsEmpty())
 	{
@@ -95,7 +95,7 @@ void UFileFromStorageUploader::UploadFileFromStorage(const FString& URL, const F
 	}
 
 	RuntimeChunkDownloaderPtr = MakeShared<FRuntimeChunkDownloader>();
-	RuntimeChunkDownloaderPtr->UploadFile(URL, Timeout, Body, OnProgress).Next(OnResult);
+	RuntimeChunkDownloaderPtr->UploadFile(URL, Timeout, Body, OnProgress, Headers).Next(OnResult);
 }
 
 void UFileFromStorageUploader::OnComplete_Internal(EUploadFromStorageResult Result)

--- a/Source/RuntimeFilesDownloader/Private/RuntimeChunkDownloader.cpp
+++ b/Source/RuntimeFilesDownloader/Private/RuntimeChunkDownloader.cpp
@@ -584,7 +584,7 @@ void FRuntimeChunkDownloader::CancelDownload()
 }
 
 TFuture<FRuntimeChunkUploaderResult> FRuntimeChunkDownloader::UploadFile(
-	const FString& URL, float Timeout, TArray<uint8>& Body, const TFunction<void(int64, int64)>& OnProgress)
+	const FString& URL, float Timeout, TArray<uint8>& Body, const TFunction<void(int64, int64)>& OnProgress, const TMap<FString, FString>& Headers)
 {
 	TWeakPtr<FRuntimeChunkDownloader> WeakThisPtr = AsShared();
 
@@ -592,7 +592,10 @@ TFuture<FRuntimeChunkUploaderResult> FRuntimeChunkDownloader::UploadFile(
 	HttpRequestRef->SetVerb("PUT");
 	HttpRequestRef->SetURL(URL);
 	HttpRequestRef->SetTimeout(Timeout);
-
+	for (const auto& Header : Headers)
+	{
+		HttpRequestRef->SetHeader(Header.Key, Header.Value);
+	}
 	HttpRequestRef->SetContent(Body);
 	auto ContentSize = Body.Num();
 

--- a/Source/RuntimeFilesDownloader/Public/FileFromStorageUploader.h
+++ b/Source/RuntimeFilesDownloader/Public/FileFromStorageUploader.h
@@ -59,10 +59,12 @@ public:
 	 * @param Timeout The maximum time to wait for the upload to complete, in seconds.
 	 * @param OnProgress Delegate for upload progress updates
 	 * @param OnComplete Delegate for broadcasting the completion of the upload
+	 * @param Headers Additional request headers to include in the request
 	 */
 	static UFileFromStorageUploader* UploadFileFromStorage(const FString& URL, const FString& SavePath, float Timeout,
 														   const FOnDownloadProgressNative& OnProgress, const
-														   FOnFileFromStorageUploadCompleteNative& OnComplete);
+														   FOnFileFromStorageUploadCompleteNative& OnComplete,
+														   const TMap<FString, FString>& Headers = TMap<FString, FString>());
 
 	//~ Begin UBaseFilesDownloader Interface
 	virtual bool CancelDownload() override;
@@ -75,8 +77,9 @@ protected:
 	 * @param URL The URL for the file to be uploaded to
 	 * @param FilePath The absolute path and file name to load the file from
 	 * @param Timeout The maximum time to wait for the upload to complete, in seconds.
+	 * @param Headers Additional request headers to include in the request
 	 */
-	void UploadFileFromStorage(const FString& URL, const FString& FilePath, float Timeout);
+	void UploadFileFromStorage(const FString& URL, const FString& FilePath, float Timeout, const TMap<FString, FString>& Headers = TMap<FString, FString>());
 
 	/**
 	 * Internal callback for when file uploading has finished

--- a/Source/RuntimeFilesDownloader/Public/RuntimeChunkDownloader.h
+++ b/Source/RuntimeFilesDownloader/Public/RuntimeChunkDownloader.h
@@ -126,10 +126,11 @@ public:
 	 * @param Timeout The timeout value in seconds
 	 * @param Body The raw file bytes to upload
 	 * @param OnProgress A function that is called with the progress as BytesSent and ContentSize
+	 * @param Headers Additional request headers to include in the request
 	 * @return A future that resolves to the response code of the upload
 	 */
 	TFuture<FRuntimeChunkUploaderResult> UploadFile(const FString& URL, float Timeout, TArray<uint8>& Body,
-		const TFunction<void(int64, int64)>&                       OnProgress);
+		const TFunction<void(int64, int64)>& OnProgress, const TMap<FString, FString>& Headers = TMap<FString, FString>());
 
 	/**
 	 * Get the content size of the file to be downloaded


### PR DESCRIPTION
Not supported for blueprint invocation, because there's no easy replacement for TMap<> in Blueprints.